### PR TITLE
Improvement/refactor graph into grid

### DIFF
--- a/Cattac/Cattac.xcodeproj/project.pbxproj
+++ b/Cattac/Cattac.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		763E712F1AD2F6AE00E90EF0 /* PuiButtonPressed.png in Resources */ = {isa = PBXBuildFile; fileRef = 763E712D1AD2F6AE00E90EF0 /* PuiButtonPressed.png */; };
 		763E71311AD2FC6800E90EF0 /* DirectionSelected.png in Resources */ = {isa = PBXBuildFile; fileRef = 763E71301AD2FC6800E90EF0 /* DirectionSelected.png */; };
 		763E71331AD2FFB200E90EF0 /* SKDirectionButtonNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763E71321AD2FFB200E90EF0 /* SKDirectionButtonNode.swift */; };
+		7661CF481AD4333E0004B0FD /* GridIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7661CF471AD4333E0004B0FD /* GridIndex.swift */; };
+		7661CF4A1AD4336C0004B0FD /* Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7661CF491AD4336C0004B0FD /* Direction.swift */; };
 		76FC46E21ABFE6190056B5F5 /* Grumpy.png in Resources */ = {isa = PBXBuildFile; fileRef = 76FC46DD1ABFE6190056B5F5 /* Grumpy.png */; };
 		76FC46E31ABFE6190056B5F5 /* Nala.png in Resources */ = {isa = PBXBuildFile; fileRef = 76FC46DE1ABFE6190056B5F5 /* Nala.png */; };
 		76FC46E41ABFE6190056B5F5 /* Nyan.png in Resources */ = {isa = PBXBuildFile; fileRef = 76FC46DF1ABFE6190056B5F5 /* Nyan.png */; };
@@ -162,6 +164,8 @@
 		763E712D1AD2F6AE00E90EF0 /* PuiButtonPressed.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = PuiButtonPressed.png; path = Images.xcassets/PuiButtonPressed.png; sourceTree = "<group>"; };
 		763E71301AD2FC6800E90EF0 /* DirectionSelected.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = DirectionSelected.png; path = Images.xcassets/DirectionSelected.png; sourceTree = "<group>"; };
 		763E71321AD2FFB200E90EF0 /* SKDirectionButtonNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKDirectionButtonNode.swift; sourceTree = "<group>"; };
+		7661CF471AD4333E0004B0FD /* GridIndex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridIndex.swift; sourceTree = "<group>"; };
+		7661CF491AD4336C0004B0FD /* Direction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Direction.swift; sourceTree = "<group>"; };
 		76FC46DD1ABFE6190056B5F5 /* Grumpy.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Grumpy.png; path = Images.xcassets/Grumpy.png; sourceTree = "<group>"; };
 		76FC46DE1ABFE6190056B5F5 /* Nala.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Nala.png; path = Images.xcassets/Nala.png; sourceTree = "<group>"; };
 		76FC46DF1ABFE6190056B5F5 /* Nyan.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Nyan.png; path = Images.xcassets/Nyan.png; sourceTree = "<group>"; };
@@ -231,7 +235,7 @@
 			isa = PBXGroup;
 			children = (
 				342585081AACDC41004A3CFD /* DataStructures */,
-				342585091AACDC66004A3CFD /* Graph */,
+				7661CF461AD432470004B0FD /* Grid */,
 				76FC46E61ABFE62E0056B5F5 /* Images */,
 				3425850B1AACDCD1004A3CFD /* MusicFiles */,
 				3425850D1AACDD5E004A3CFD /* MusicPlayer */,
@@ -321,7 +325,6 @@
 				3425851E1AACDF61004A3CFD /* Node.swift */,
 				342585201AACDF7A004A3CFD /* Edge.swift */,
 				342585221AACDF91004A3CFD /* Graph.swift */,
-				76FC46E91ABFEB4E0056B5F5 /* Grid.swift */,
 			);
 			name = Graph;
 			sourceTree = "<group>";
@@ -485,6 +488,17 @@
 			name = Actions;
 			sourceTree = "<group>";
 		};
+		7661CF461AD432470004B0FD /* Grid */ = {
+			isa = PBXGroup;
+			children = (
+				342585091AACDC66004A3CFD /* Graph */,
+				76FC46E91ABFEB4E0056B5F5 /* Grid.swift */,
+				7661CF471AD4333E0004B0FD /* GridIndex.swift */,
+				7661CF491AD4336C0004B0FD /* Direction.swift */,
+			);
+			name = Grid;
+			sourceTree = "<group>";
+		};
 		76FC46E61ABFE62E0056B5F5 /* Images */ = {
 			isa = PBXGroup;
 			children = (
@@ -634,6 +648,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7661CF481AD4333E0004B0FD /* GridIndex.swift in Sources */,
 				342585391AACE0E6004A3CFD /* DoodadFactory.swift in Sources */,
 				763E71291AD2F26500E90EF0 /* SKActionButtonNode.swift in Sources */,
 				3471CA681ACEA02300B0E68D /* GameDifficultyViewController.swift in Sources */,
@@ -641,6 +656,7 @@
 				3425854E1AACE291004A3CFD /* HardLevel.swift in Sources */,
 				342584E71AACDB03004A3CFD /* GameScene.swift in Sources */,
 				761BB59E1AD04348007C31C1 /* Action.swift in Sources */,
+				7661CF4A1AD4336C0004B0FD /* Direction.swift in Sources */,
 				342585451AACE22C004A3CFD /* Item.swift in Sources */,
 				BDA19AC01AD0609200B7E9D4 /* WatchTowerDoodad.swift in Sources */,
 				34DFC1541ACEF5B400B9073C /* LoginViewController.swift in Sources */,

--- a/Cattac/Cattac/Action.swift
+++ b/Cattac/Cattac/Action.swift
@@ -38,39 +38,6 @@ extension ActionType: Printable {
     }
 }
 
-enum Direction: Int {
-    case All = 0, Top, Right, Bottom, Left
-    private var name: String {
-        let names = [
-            "all directions",
-            "top direction",
-            "right direction",
-            "bottom direction",
-            "left direction"
-        ]
-        
-        return names[rawValue]
-    }
-}
-
-extension Direction: Printable {
-    var description: String {
-        return name
-    }
-    
-    static func create(name: String) -> Direction? {
-        let types = [
-            "all directions": Direction.All,
-            "top direction": Direction.Top,
-            "right direction": Direction.Right,
-            "bottom direction": Direction.Bottom,
-            "left direction": Direction.Left
-        ]
-        
-        return types[name]
-    }
-}
-
 class Action: Equatable {
     private var _actionType: ActionType!
     private var _direction: Direction!

--- a/Cattac/Cattac/Direction.swift
+++ b/Cattac/Cattac/Direction.swift
@@ -1,0 +1,38 @@
+/// Enumeration of all the possible directions that can be applied on a square
+/// grid.
+enum Direction: Int {
+    case All = 0, Top, Right, Bottom, Left
+    private var name: String {
+        let names = [
+            "all directions",
+            "top direction",
+            "right direction",
+            "bottom direction",
+            "left direction"
+        ]
+
+        return names[rawValue]
+    }
+}
+
+extension Direction: Printable {
+    var description: String {
+        return name
+    }
+
+    /// Creates a Direction from a string value.
+    ///
+    /// :param: name The string representation of a Direction.
+    /// :returns: A Direction of the given string input or nil if the string input is invalid.
+    static func create(name: String) -> Direction? {
+        let types = [
+            "all directions": Direction.All,
+            "top direction": Direction.Top,
+            "right direction": Direction.Right,
+            "bottom direction": Direction.Bottom,
+            "left direction": Direction.Left
+        ]
+
+        return types[name]
+    }
+}

--- a/Cattac/Cattac/Edge.swift
+++ b/Cattac/Cattac/Edge.swift
@@ -1,23 +1,21 @@
-/*
-    `Edge` represents an edge in a graph. An `Edge` is associated with
-    a source Node, a destination Node and a non-negative cost (or weight).
-    This means that `Edge` is a directed edge from the source to
-    the destination.
-
-    The representation invariants:
-    - The weight is non-negative
-
-    Similar to `Node`, `Edge` is a generic type with a type parameter
-    `T` that is the type of a node's label.
-*/
-
+/// `Edge` represents an edge in a graph. An `Edge` is associated with
+/// a source Node, a destination Node and a non-negative cost (or weight).
+/// This means that `Edge` is a directed edge from the source to
+/// the destination.
+///
+/// The representation invariants:
+///
+/// - The weight is non-negative
+///
+/// Similar to `Node`, `Edge` is a generic type with a type parameter
+/// `T` that is the type of a node's label
 struct Edge<T: Hashable> {
     typealias N = Node<T>
     
     private var source: N
     private var destination: N
     private var weight = 1.0
-    
+
     init(source: N, destination: N) {
         self.source = source
         self.destination = destination
@@ -83,5 +81,7 @@ extension Edge: Hashable {
 
 //  Return true if `lhs` edge is equal to `rhs` edge.
 func ==<Label>(lhs: Edge<Label>, rhs: Edge<Label>) -> Bool {
-    return lhs.source == rhs.source && lhs.destination == rhs.destination && lhs.weight == rhs.weight
+    return lhs.source == rhs.source
+        && lhs.destination == rhs.destination
+        && lhs.weight == rhs.weight
 }

--- a/Cattac/Cattac/GameEngine.swift
+++ b/Cattac/Cattac/GameEngine.swift
@@ -309,7 +309,7 @@ class GameEngine {
     }
     
     func pathOfPui(startNode: TileNode, direction: Direction) -> [TileNode] {
-        let offset = grid.neighboursOffset[direction.description]!
+        let offset = grid.neighboursOffset[direction]!
         var path = [TileNode]()
         var currentNode = startNode
         while let nextNode = grid[currentNode.row, currentNode.column, with: offset] {

--- a/Cattac/Cattac/GameEngine.swift
+++ b/Cattac/Cattac/GameEngine.swift
@@ -24,18 +24,16 @@ class GameEngine {
     var actionListener: ActionListener?
     var player: Cat!
     var playerMoveNumber: Int = 1
-    private var grid: Grid<TileNode>!
-    private var graph: Graph<TileNode>!
+    private var grid: Grid!
     private var allPlayerPositions: [String:TileNode] = [:]
     private var allPlayerMoveToPositions: [String:TileNode] = [:]
     private var allPlayerActions: [String:Action] = [:]
-    var reachableNodes: [Int:Node<TileNode>] = [:]
+    var reachableNodes: [Int:TileNode] = [:]
     var removedDoodads: [Int:Doodad] = [:]
     private var events: [String:()->()] = [:]
     
-    init(grid: Grid<TileNode>, graph: Graph<TileNode>) {
+    init(grid: Grid) {
         self.grid = grid
-        self.graph = graph
         addPlayers()
         
         self.on("puiButtonPressed") {
@@ -224,7 +222,7 @@ class GameEngine {
         }
         
         currentPlayerMoveToNode = currentPlayerNode
-        reachableNodes = graph.getNodesInRange(Node(currentPlayerNode), range: player.moveRange)
+        reachableNodes = grid.getNodesInRange(currentPlayerNode, range: player.moveRange)
         allPlayerActions = [:]
     }
     
@@ -303,9 +301,9 @@ class GameEngine {
         events[event] = lambda
     }
     
-    func pathTo(node: TileNode) -> [Edge<TileNode>] {
+    func pathTo(node: TileNode) -> [TileNode] {
         let fromNode = allPlayerPositions[player.name]!
-        let edges = graph.shortestPathFromNode(Node(fromNode), toNode: Node(node))
+        let edges = grid.shortestPathFromNode(fromNode, toNode: node)
         currentPlayerNode = node
         return edges
     }
@@ -314,16 +312,15 @@ class GameEngine {
         let offset = grid.neighboursOffset[direction.description]!
         var path = [TileNode]()
         var currentNode = startNode
-        while let nextNode = grid[currentNode.row + offset.row,
-            currentNode.column + offset.column] {
-                if let doodad = nextNode.doodad {
-                    if doodad.getName() == "wall" {
-                        path.append(nextNode)
-                        break
-                    }
+        while let nextNode = grid[currentNode.row, currentNode.column, with: offset] {
+            if let doodad = nextNode.doodad {
+                if doodad.getName() == "wall" {
+                    path.append(nextNode)
+                    break
                 }
-                path.append(nextNode)
-                currentNode = nextNode
+            }
+            path.append(nextNode)
+            currentNode = nextNode
         }
         return path
     }
@@ -337,25 +334,9 @@ class GameEngine {
     }
     
     private func setAvailableDirections() {
-        let originNode = self.currentPlayerMoveToNode
-        var directionIsSet = false
-        var action: PuiAction!
-        for (direction, offset) in grid.neighboursOffset {
-            if let targetNode = grid[originNode.row + offset.row,
-                originNode.column + offset.column] {
-                    let edges = graph.edgesFromNode(Node(originNode), toNode: Node(targetNode))
-                    if edges.count > 0 {
-                        let dir = Direction.create(direction)!
-                        if !directionIsSet {
-                            action = PuiAction(direction: dir)
-                            directionIsSet = true
-                        }
-                        action.availableDirections.append(dir)
-                    }
-            }
-        }
-        if action != nil {
-            currentPlayerAction = action
-        }
+        let availableDirections = grid.getAvailableDirections(currentPlayerMoveToNode)
+        var action = PuiAction(direction: availableDirections.first!)
+        action.availableDirections = availableDirections
+        currentPlayerAction = action
     }
 }

--- a/Cattac/Cattac/GameLevel.swift
+++ b/Cattac/Cattac/GameLevel.swift
@@ -11,7 +11,7 @@ class GameLevel {
     init(rows: Int, columns: Int) {
         numColumns = columns
         numRows = rows
-        grid = Grid(columns: numColumns, rows: numRows)
+        grid = Grid(rows: numRows, columns: numColumns)
     }
     
     func nodeAt(row: Int, _ column: Int) -> TileNode? {

--- a/Cattac/Cattac/GameLevel.swift
+++ b/Cattac/Cattac/GameLevel.swift
@@ -6,31 +6,12 @@ class GameLevel {
     var numDoodads: Int = Constants.Level.defaultDoodads
     var numWalls: Int = Constants.Level.defaultWalls
     
-    var grid: Grid<TileNode>!
-    var graph: Graph<TileNode>!
+    var grid: Grid!
     
     init(rows: Int, columns: Int) {
         numColumns = columns
         numRows = rows
-        grid = Grid<TileNode>(columns: numColumns, rows: numRows)
-        graph = Graph(isDirected: true)
-    }
-    
-    func constructGraph() {
-        // Add all the nodes to the graph first
-        for node in grid {
-            graph.addNode(Node(node))
-        }
-        
-        // Adds the edges by finding the neighbours of each node
-        for sourceNode in grid {
-            for (direction, offset) in grid.neighboursOffset {
-                if let destNode = grid[sourceNode.row + offset.row,
-                    sourceNode.column + offset.column] {
-                        graph.addEdge(Edge(source: Node(sourceNode), destination: Node(destNode)))
-                }
-            }
-        }
+        grid = Grid(columns: numColumns, rows: numRows)
     }
     
     func nodeAt(row: Int, _ column: Int) -> TileNode? {

--- a/Cattac/Cattac/GameScene.swift
+++ b/Cattac/Cattac/GameScene.swift
@@ -37,7 +37,7 @@ class GameScene: SKScene, GameStateListener, ActionListener {
         super.init(size: size)
         
         self.level = level
-        gameEngine = GameEngine(grid: level.grid, graph: level.graph)
+        gameEngine = GameEngine(grid: level.grid)
         gameEngine.gameStateListener = self
         gameEngine.actionListener = self
         
@@ -194,9 +194,8 @@ class GameScene: SKScene, GameStateListener, ActionListener {
         let path = gameEngine.pathTo(gameEngine.currentPlayerMoveToNode)
         var pathSequence: [SKAction] = []
 
-        for edge in path {
-            let destNode = edge.getDestination().getLabel()
-            let action = SKAction.moveTo(destNode.sprite.position, duration: 0.25)
+        for node in path {
+            let action = SKAction.moveTo(node.sprite.position, duration: 0.25)
             pathSequence.append(action)
         }
         
@@ -332,13 +331,13 @@ class GameScene: SKScene, GameStateListener, ActionListener {
     
     private func highlightReachableNodes() {
         for node in gameEngine.reachableNodes.values {
-            node.getLabel().highlight()
+            node.highlight()
         }
     }
     
     private func removeHighlights() {
         for node in gameEngine.reachableNodes.values {
-            node.getLabel().unhighlight()
+            node.unhighlight()
         }
     }
     

--- a/Cattac/Cattac/Graph.swift
+++ b/Cattac/Cattac/Graph.swift
@@ -330,33 +330,4 @@ class Graph<T: Hashable> {
         
         return arrayToReturn.reverse()
     }
-    
-    func getNodesInRange(fromNode: N, range: Int) -> [Int:N] {
-        var nodes: [Int:N] = [:]
-        var neighbours: [N] = []
-        
-        if range == 0 {
-            return nodes
-        }
-        
-        if let edgesFromSourceNode = adjacencyList[fromNode.hashValue] {
-            for (destNodeHash, _) in edgesFromSourceNode {
-                let node = dictionaryOfNodes[destNodeHash]!
-                nodes[destNodeHash] = node
-                neighbours.append(node)
-            }
-        }
-        
-        // Add neighbours of neighbours
-        for node in neighbours {
-            let nodeNeighbours = getNodesInRange(node, range: range - 1)
-            for (hash, nodeNeighbour) in nodeNeighbours {
-                if nodes[hash] == nil {
-                    nodes[hash] = nodeNeighbour
-                }
-            }
-        }
-
-        return nodes
-    }
 }

--- a/Cattac/Cattac/Graph.swift
+++ b/Cattac/Cattac/Graph.swift
@@ -1,59 +1,76 @@
-/*
-    `Graph` represents a graph (unsurprisingly!) More specifically, `Graph`
-    should be able to represent the following graph types with corresponding
-    constraints:
-    - Undirected graph
-    + An undirected edge is represented by 2 directed edges
-    - Directed graph
-    - Simple graph
-    - Multigraph
-    + Edges from the same source to the same destination should have
-    different cost
-    - Unweighted graph
-    + Edges' weights are to set to 1.0
-    - Weighted graph
-
-    Hence, the representation invariants for every Graph g:
-    - g is either directed or undirected
-    - All nodes in g must have unique labels
-    - Multiple edges from the same source to the same destination must
-    not have the same weight
-
-    Finally, just like `Node` and `Edge`, `Graph` is a generic type with a type
-    parameter `T` that defines the type of the nodes' labels.
-*/
-
+/// `Graph` represents a graph (unsurprisingly!) More specifically, `Graph`
+/// should be able to represent the following graph types with corresponding
+/// constraints:
+///
+/// - Undirected graph
+/// - An undirected edge is represented by 2 directed edges
+/// - Directed graph
+/// - Simple graph
+/// - Multigraph
+/// - Edges from the same source to the same destination should have different 
+///   cost
+/// - Unweighted graph
+/// - Edges' weights are to set to 1.0
+/// - Weighted graph
+///
+/// Hence, the representation invariants for every Graph g:
+///
+/// - g is either directed or undirected
+/// - All nodes in g must have unique labels
+/// - Multiple edges from the same source to the same destination must not have 
+///   the same weight
+///
+/// Finally, just like `Node` and `Edge`, `Graph` is a generic type with a type
+/// parameter `T` that defines the type of the nodes' labels.
+///
 class Graph<T: Hashable> {
     typealias N = Node<T>
     typealias E = Edge<T>
-    
+
+    /// Whether the graph is a directed or undirected graph.
     let isDirected: Bool
+
+    /// A dictionary of all the nodes in the graph for fast retrieval of nodes.
     private var dictionaryOfNodes: [Int:N]
+
+    /// A dictionary of all the edges in the graph for fast retrieval of edges.
     private var dictionaryOfEdges: [Int:E]
-    private var adjacencyList: [Int:[Int:[E]]]
+
+    /// Graph is represented using this matrix, each entry in this matrix will
+    /// contain an array of different edges (i.e. different weights since they
+    /// have the same source and destination node)
+    private var matrix: [Int:[Int:[E]]]
     
-    //  Construct a directed or undirected graph.
+    /// Constructs a directed or undirected graph.
+    ///
+    /// :param: isDirected Whether to construct a directed or undirected graph.
     init(isDirected: Bool) {
         self.isDirected = isDirected
         self.dictionaryOfNodes = [:]
         self.dictionaryOfEdges = [:]
-        self.adjacencyList = [:]
+        self.matrix = [:]
         
         _checkRep()
     }
-    
+
+    /// Adds a node into the graph.
+    ///
+    /// :param: addedNode The node to be added.
     func addNode(addedNode: N) {
         _checkRep()
         
         if !containsNode(addedNode) {
             let addedNodeHash = addedNode.hashValue
             dictionaryOfNodes[addedNodeHash] = addedNode
-            adjacencyList[addedNodeHash] = [:]
+            matrix[addedNodeHash] = [:]
         }
         
         _checkRep()
     }
-    
+
+    /// Removes a node from the graph and all its incoming and outgoing edges.
+    ///
+    /// :param: removedNode The node to be removed.
     func removeNode(removedNode: N) {
         _checkRep()
         
@@ -66,11 +83,11 @@ class Graph<T: Hashable> {
             if isDirected {
                 // Remove all edges that goes to the removed node
                 for (nodeKey, _) in dictionaryOfNodes {
-                    adjacencyList[nodeKey]!.removeValueForKey(removedNodeHash)
+                    matrix[nodeKey]!.removeValueForKey(removedNodeHash)
                 }
             } else {
                 // Remove all undirected edges for the removed node
-                if let outgoingEdges = adjacencyList[removedNodeHash] {
+                if let outgoingEdges = matrix[removedNodeHash] {
                     for (_, edges) in outgoingEdges {
                         for edge in edges {
                             removeEdge(edge)
@@ -80,12 +97,16 @@ class Graph<T: Hashable> {
             }
             
             // Remove adjacency list entry for the removed node
-            adjacencyList.removeValueForKey(removedNodeHash)
+            matrix.removeValueForKey(removedNodeHash)
         }
     
         _checkRep()
     }
-    
+
+    /// Checks whether the node exists in the graph.
+    ///
+    /// :param: targetNode The node to check.
+    /// :returns: true if it exists, false if it doesn't.
     func containsNode(targetNode: N) -> Bool {
         _checkRep()
         
@@ -95,20 +116,25 @@ class Graph<T: Hashable> {
             return false
         }
     }
-    
+
+    /// Adds an edge into the graph. Creates the source and destination nodes
+    /// if they do not exist.
+    ///
+    /// :param: addedEdge The edge to be added.
     func addEdge(addedEdge: E) {
         _checkRep()
-        
+
+        /// Adds a directed edge into the graph.
         func addDirectedEdge(edge: E, sourceNodeHash: Int, destNodeHash: Int) {
-            if let sourceNodeEdges = adjacencyList[sourceNodeHash] {
+            if let sourceNodeEdges = matrix[sourceNodeHash] {
                 if sourceNodeEdges[destNodeHash] == nil {
-                    adjacencyList[sourceNodeHash]![destNodeHash] = [edge]
+                    matrix[sourceNodeHash]![destNodeHash] = [edge]
                 } else {
-                    adjacencyList[sourceNodeHash]![destNodeHash]!.append(edge)
+                    matrix[sourceNodeHash]![destNodeHash]!.append(edge)
                 }
             } else {
                 let edges = [destNodeHash:[edge]]
-                adjacencyList[sourceNodeHash] = edges
+                matrix[sourceNodeHash] = edges
             }
         }
         
@@ -139,18 +165,25 @@ class Graph<T: Hashable> {
         
         _checkRep()
     }
-    
+
+    /// Removes an edge from the graph.
+    ///
+    /// :param: removedEdge The edge to be removed.
     func removeEdge(removedEdge: E) {
         _checkRep()
-        
-        func removeDirectedEdge(edge: E, sourceNodeHash: Int, destNodeHash: Int) {
-            if let edgesFromSourceNode = adjacencyList[sourceNodeHash] {
-                let edgesFromSourceNodeToDestNode = edgesFromSourceNode[destNodeHash]!
+
+        /// Removes an directed edge from the graph.
+        func removeDirectedEdge(edge: E, source: Int, dest: Int) {
+            if let edgesFromSourceNode = matrix[source] {
+                let edgesFromSourceNodeToDestNode = edgesFromSourceNode[dest]!
+
                 if edgesFromSourceNodeToDestNode.count > 1 {
-                    adjacencyList[sourceNodeHash]![destNodeHash] =
-                        edgesFromSourceNodeToDestNode.filter() { $0 != removedEdge }
+                    matrix[source]![dest] =
+                        edgesFromSourceNodeToDestNode.filter() {
+                            $0 != removedEdge
+                        }
                 } else {
-                    adjacencyList[sourceNodeHash]!.removeValueForKey(destNodeHash)
+                    matrix[source]!.removeValueForKey(dest)
                 }
             }
         }
@@ -174,7 +207,11 @@ class Graph<T: Hashable> {
         
         _checkRep()
     }
-    
+
+    /// Checks whether the edge exists in the graph.
+    ///
+    /// :param: targetEdge The edge to check.
+    /// :returns: true if it exists, false if it doesn't.
     func containsEdge(targetEdge: E) -> Bool {
         _checkRep()
         
@@ -184,25 +221,37 @@ class Graph<T: Hashable> {
             return false
         }
     }
-    
+
+    /// Retrieves all edges that points from the fromNode to toNode.
+    ///
+    /// :param: fromNode The source node of the edges.
+    /// :param: toNode The destination node of the edges.
+    /// :returns: An array of edges, empty if none found.
     func edgesFromNode(fromNode: N, toNode: N) -> [E] {
         _checkRep()
-        
-        if let edgesFromSourceNode = adjacencyList[fromNode.hashValue] {
-            if let edgesFromSourceNodeToDestNode = edgesFromSourceNode[toNode.hashValue] {
-                return edgesFromSourceNodeToDestNode
+
+        // Retrieve from matrix.
+        if let edgesFromSourceNode = matrix[fromNode.hashValue] {
+            if let edgesFromSourceNodeToDestNode =
+                edgesFromSourceNode[toNode.hashValue] {
+                    return edgesFromSourceNodeToDestNode
             }
         }
         
         return []
     }
-    
+
+    /// Retrieves all neighbours of the given node.
+    ///
+    /// :param: fromNode The node to grab neighbours from.
+    /// :returns: An array of nodes, empty if none found.
     func adjacentNodesFromNode(fromNode: N) -> [N] {
         _checkRep()
         
         var arrayToReturn = [N]()
-        
-        if let edgesFromSourceNode = adjacencyList[fromNode.hashValue] {
+
+        // Retrieve from matrix.
+        if let edgesFromSourceNode = matrix[fromNode.hashValue] {
             for key in edgesFromSourceNode.keys {
                 arrayToReturn.append(dictionaryOfNodes[key]!)
             }
@@ -210,22 +259,28 @@ class Graph<T: Hashable> {
         
         return arrayToReturn
     }
-    
+
+    /// An array of all the nodes in the graph.
     var nodes: [N] {
         return [N](self.dictionaryOfNodes.values)
     }
-    
+
+    /// An array of all the edges in the graph.
     var edges: [E] {
         return [E](self.dictionaryOfEdges.values)
     }
-    
+
+    /// Disabled to improve performance.
     private func _checkRep() {
-        // disabling checks to reduce latency
-        // assert(isDirected == true || isDirected == false, "A graph has to be either directed or undirected")
-        //
-        // assert(isLabelAllUnique() == true, "A graph G must have unique labels")
-        //
-        // assert(isEdgesAllUnique() == true, "If there are multiples edges from the same source to the same destination, then they cannot be of the same weight")
+//         assert(isDirected == true || isDirected == false,
+//            "A graph has to be either directed or undirected")
+//        
+//         assert(isLabelAllUnique() == true,
+//            "A graph G must have unique labels")
+//        
+//         assert(isEdgesAllUnique() == true,
+//            "If there are multiples edges from the same source to the same " +
+//            "destination, then they cannot be of the same weight")
     }
     
     func isLabelAllUnique() -> Bool {
@@ -234,10 +289,11 @@ class Graph<T: Hashable> {
         for var index = 0; index < numberOfNodes; index++ {
             var labelToCheck = nodes[index]
             
-            for var innerIndex = index + 1; innerIndex < numberOfNodes; innerIndex++ {
-                if labelToCheck == nodes[innerIndex] {
-                    return false
-                }
+            for var innerIndex = index + 1; innerIndex < numberOfNodes;
+                innerIndex++ {
+                    if labelToCheck == nodes[innerIndex] {
+                        return false
+                    }
             }
         }
         
@@ -250,16 +306,23 @@ class Graph<T: Hashable> {
         for var index = 0; index < numberOfEdges; index++ {
             var edgeToCheck = edges[index]
             
-            for var innerIndex = index + 1; innerIndex < numberOfEdges; innerIndex++ {
-                if edgeToCheck == edges[innerIndex] {
-                    return false
-                }
+            for var innerIndex = index + 1; innerIndex < numberOfEdges;
+                innerIndex++ {
+                    if edgeToCheck == edges[innerIndex] {
+                        return false
+                    }
             }
         }
         
         return true
     }
-    
+
+    /// Find the shortest path from fromNode to toNode.
+    ///
+    /// :param: fromNode The starting node for the path.
+    /// :param: toNode The ending node for the path.
+    /// :returns: An array of edges that forms the shortest path, empty if path
+    ///           not found.
     func shortestPathFromNode(fromNode: N, toNode: N) -> [E] {
         _checkRep()
         
@@ -315,7 +378,7 @@ class Graph<T: Hashable> {
         // Dijkstra's algorithm
         while !queue.isEmpty {
             var (node, distance) = queue.removeLast()
-            if let edgesFromSourceNode = adjacencyList[node.hashValue] {
+            if let edgesFromSourceNode = matrix[node.hashValue] {
                 for (_, edges) in edgesFromSourceNode {
                     for edge in edges {
                         relax(edge, distance)

--- a/Cattac/Cattac/Graph.swift
+++ b/Cattac/Cattac/Graph.swift
@@ -131,7 +131,9 @@ class Graph<T: Hashable> {
             addDirectedEdge(addedEdge, sourceNodeHash, destNodeHash)
             
             if !self.isDirected {
-                addDirectedEdge(addedEdge.reverse(), destNodeHash, sourceNodeHash)
+                let reversedEdge = addedEdge.reverse()
+                dictionaryOfEdges[reversedEdge.hashValue] = reversedEdge
+                addDirectedEdge(reversedEdge, destNodeHash, sourceNodeHash)
             }
         }
         
@@ -164,7 +166,9 @@ class Graph<T: Hashable> {
             removeDirectedEdge(removedEdge, sourceNodeHash, destNodeHash)
             
             if !self.isDirected {
-                removeDirectedEdge(removedEdge.reverse(), destNodeHash, sourceNodeHash)
+                let reversedEdge = removedEdge.reverse()
+                dictionaryOfEdges.removeValueForKey(reversedEdge.hashValue)
+                removeDirectedEdge(reversedEdge, destNodeHash, sourceNodeHash)
             }
         }
         
@@ -319,13 +323,16 @@ class Graph<T: Hashable> {
                 }
             }
         }
-        
-        var prevNode = toNode
-        
-        // Construct path
-        while let edge = nodeInfo[prevNode.hashValue]!.incomingEdge {
-            arrayToReturn.append(edge)
-            prevNode = edge.getSource()
+
+        // Adds the edges only if a path to toNode is found
+        if nodeInfo[toNode.hashValue] != nil {
+            var prevNode = toNode
+            
+            // Construct path
+            while let edge = nodeInfo[prevNode.hashValue]!.incomingEdge {
+                arrayToReturn.append(edge)
+                prevNode = edge.getSource()
+            }
         }
         
         return arrayToReturn.reverse()

--- a/Cattac/Cattac/Grid.swift
+++ b/Cattac/Cattac/Grid.swift
@@ -78,7 +78,7 @@ class Grid {
         }
     }
 
-    /// TileNode with the given offset from the base TileNode with the given
+    /// TileNode with the given offset from the base TileNode of the given
     /// row and column.
     ///
     /// :throws: KeyError exception if trying to set to an invalid grid index
@@ -167,7 +167,7 @@ class Grid {
         return path
     }
 
-    /// Get all the available directions of a given TileNode. Availabe
+    /// Get all the available directions of a given TileNode. Available
     /// directions being directions where another reachable TileNode exists.
     ///
     /// :param: fromNode The TileNode to be used to find available directions.
@@ -189,7 +189,7 @@ class Grid {
 }
 
 extension Grid: SequenceType {
-    /// Generator for Grid to allow it to be iterable
+    /// Generator for Grid to allow it to be iterable.
     ///
     /// :returns: A generator of TileNodes.
     func generate() -> GeneratorOf<TileNode> {

--- a/Cattac/Cattac/Grid.swift
+++ b/Cattac/Cattac/Grid.swift
@@ -16,7 +16,7 @@ class Grid {
         "left direction": (0, -1)
     ]
     
-    init(columns: Int, rows: Int) {
+    init(rows: Int, columns: Int) {
         self.columns = columns
         self.rows = rows
         self.graph = Graph<TileNode>(isDirected: true)

--- a/Cattac/Cattac/Grid.swift
+++ b/Cattac/Cattac/Grid.swift
@@ -9,11 +9,11 @@ class Grid {
     private var grid: [GridIndex:TileNode] = [:]
     private var graph: Graph<TileNode>
     
-    let neighboursOffset: [String:(row: Int, column: Int)] = [
-        "top direction": (1, 0),
-        "right direction": (0, 1),
-        "bottom direction": (-1, 0),
-        "left direction": (0, -1)
+    let neighboursOffset: [Direction:(row: Int, column: Int)] = [
+        .Top: (1, 0),
+        .Right: (0, 1),
+        .Bottom: (-1, 0),
+        .Left: (0, -1)
     ]
     
     init(rows: Int, columns: Int) {
@@ -111,7 +111,7 @@ class Grid {
             if let toNode = self[fromNode.row, fromNode.column, with: offset] {
                 let edges = graph.edgesFromNode(Node(fromNode), toNode: Node(toNode))
                 if edges.count > 0 {
-                    directions.append(Direction.create(dir)!)
+                    directions.append(dir)
                 }
             }
         }

--- a/Cattac/Cattac/Grid.swift
+++ b/Cattac/Cattac/Grid.swift
@@ -207,34 +207,3 @@ extension Grid: SequenceType {
         }
     }
 }
-
-/// A structure to encapsulate the row and column information of a TileNode.
-struct GridIndex {
-    private var x: Int
-    private var y: Int
-
-    init(_ row: Int, _ col: Int) {
-        self.x = row
-        self.y = col
-    }
-
-    var row: Int {
-        return self.x
-    }
-
-    var col: Int {
-        return self.y
-    }
-}
-
-extension GridIndex: Hashable {
-    var hashValue: Int {
-        get {
-            return (UInt32(y) + UInt32(x) << 16).hashValue
-        }
-    }
-}
-
-func ==(lhs: GridIndex, rhs: GridIndex) -> Bool {
-    return lhs.hashValue == rhs.hashValue
-}

--- a/Cattac/Cattac/Grid.swift
+++ b/Cattac/Cattac/Grid.swift
@@ -1,55 +1,99 @@
-/*
-    Stores the representation of objects in the grid using the row
-    and column as reference.
-*/
-
+/// A Dictionary based square grid that stores all the tiles using GridIndex.
+///
+/// The Grid is designed to make it easy to retrieve TileNodes given the row
+/// and column. It is able to perform calculations such as:
+///
+/// - Path between any two TileNodes
+/// - All TileNodes within range of a given TileNode
+/// - All available directions of a given TileNode
 class Grid {
+
+    /// The number of columns in the grid
     let columns: Int
+
+    /// The number of rows in the grid
     let rows: Int
-    private var grid: [GridIndex:TileNode] = [:]
+
+    private var tileNodes: [GridIndex:TileNode] = [:]
     private var graph: Graph<TileNode>
     
+    /// Mapping of directions to the respective row and column offsets
     let neighboursOffset: [Direction:(row: Int, column: Int)] = [
         .Top: (1, 0),
         .Right: (0, 1),
         .Bottom: (-1, 0),
         .Left: (0, -1)
     ]
-    
+
+    /// Initialises the grid to the given rows and columns.
+    ///
+    /// The grid needs to have a graph constructed after setting all the
+    /// tileNodes by calling `constructGraph()`, in order to utilize all the
+    /// functionalities.
+    ///
+    /// :param: rows The number of rows in the grid
+    /// :param: columns The number of columns in the grid
     init(rows: Int, columns: Int) {
         self.columns = columns
         self.rows = rows
         self.graph = Graph<TileNode>(isDirected: true)
     }
-    
+
+    /// TileNode with the given grid index.
+    ///
+    /// :param: gridIndex The GridIndex of the TileNode
+    /// :returns: The TileNode with the given grid index or nil if it does not exist
     subscript(gridIndex: GridIndex) -> TileNode? {
         get {
-            return grid[gridIndex]
+            return tileNodes[gridIndex]
         }
         set {
-            grid[gridIndex] = newValue
+            tileNodes[gridIndex] = newValue
         }
     }
-    
+
+    /// TileNode of the given row and column
+    ///
+    /// :throws: KeyError exception if trying to set to an invalid grid index
+    ///
+    /// :param: row The row index of the TileNode
+    /// :param: column The column index of the TileNode
+    /// :returns: The TileNode with the given row and column or nil if it does not exist
     subscript(row: Int, column: Int) -> TileNode? {
         get {
             if row >= rows || column >= columns || row < 0 || column < 0 {
                 return nil
             }
-            return grid[GridIndex(row, column)]
+            return tileNodes[GridIndex(row, column)]
         }
         set {
             if row >= rows || column >= columns || row < 0 || column < 0 {
-                print("KeyError: Unable to add (row:\(row), column:\(column)) to grid")
+                NSException(
+                    name: "KeyError",
+                    reason: "Unable to add to Grid[\(row), \(column)]",
+                    userInfo: nil
+                ).raise()
             }
-            grid[GridIndex(row, column)] = newValue
+            tileNodes[GridIndex(row, column)] = newValue
         }
     }
-    
-    subscript(row: Int, column: Int, with offset: (row: Int, column: Int)) -> TileNode? {
-        return self[row + offset.row, column + offset.column]
+
+    /// TileNode with the given offset from the base TileNode with the given
+    /// row and column.
+    ///
+    /// :throws: KeyError exception if trying to set to an invalid grid index
+    ///
+    /// :param: row The row index of the base TileNode
+    /// :param: column The column index of the base TileNode
+    /// :param: offset The offset from the base TileNode
+    /// :returns: The TileNode with the given row and column or nil if it does not exist
+    subscript(row: Int, column: Int, with offset: (row: Int, column: Int))
+        -> TileNode? {
+            return self[row + offset.row, column + offset.column]
     }
     
+    /// Constructs the inner graph data structure of the grid so as to utilise
+    /// the advance functionalities.
     func constructGraph() {
         // Add all the nodes to the graph first
         for node in self {
@@ -59,17 +103,29 @@ class Grid {
         // Adds the edges by finding the neighbours of each node
         for sourceNode in self {
             for (direction, offset) in neighboursOffset {
-                if let destNode = self[sourceNode.row, sourceNode.column, with: offset] {
-                        graph.addEdge(Edge(source: Node(sourceNode), destination: Node(destNode)))
+                if let destNode =
+                    self[sourceNode.row, sourceNode.column, with: offset] {
+                        graph.addEdge(Edge(source: Node(sourceNode),
+                            destination: Node(destNode)))
                 }
             }
         }
     }
-    
+
+    /// Removes a TileNode from the inner graph data structure, basically 
+    /// TileNodes that you do not want to be reachable from the rest of the 
+    /// TileNodes (stuff like TileNodes with walls)
+    ///
+    /// :param: removedNode The TileNode to be removed.
     func removeNodeFromGraph(removedNode: TileNode) {
         graph.removeNode(Node(removedNode))
     }
-    
+
+    /// Retrieves a Dictionary of TileNodes that are reachable within the given
+    /// range from the given TileNode.
+    ///
+    /// :param: fromNode The center TileNode to calculate the range from.
+    /// :returns: A Dictionary of TileNodes that are within range.
     func getNodesInRange(fromNode: TileNode, range: Int) -> [Int:TileNode] {
         var nodes: [Int:TileNode] = [:]
         var neighbours: [TileNode] = []
@@ -77,7 +133,8 @@ class Grid {
         if range == 0 {
             return nodes
         }
-        
+
+        // Add neighbours
         for node in graph.adjacentNodesFromNode(Node(fromNode)) {
             nodes[node.hashValue] = node.getLabel()
             neighbours.append(node.getLabel())
@@ -87,6 +144,7 @@ class Grid {
         for node in neighbours {
             let nodeNeighbours = getNodesInRange(node, range: range - 1)
             for (hash, nodeNeighbour) in nodeNeighbours {
+                // Only add those that has not been added
                 if nodes[hash] == nil {
                     nodes[hash] = nodeNeighbour
                 }
@@ -95,7 +153,12 @@ class Grid {
         
         return nodes
     }
-    
+
+    /// Calculates the shortest path from one node to another.
+    ///
+    /// :param: fromNode The starting TileNode to be used to calculate the path.
+    /// :param: toNode The ending TileNode to be used to calculate the path.
+    /// :returns: An array of TileNodes that represents the shortest path. Empty if path does not exist.
     func shortestPathFromNode(fromNode: TileNode, toNode: TileNode) -> [TileNode] {
         var path = [TileNode]()
         for edge in graph.shortestPathFromNode(Node(fromNode), toNode: Node(toNode)) {
@@ -103,7 +166,12 @@ class Grid {
         }
         return path
     }
-    
+
+    /// Get all the available directions of a given TileNode. Availabe
+    /// directions being directions where another reachable TileNode exists.
+    ///
+    /// :param: fromNode The TileNode to be used to find available directions.
+    /// :returns: An array of available directions.
     func getAvailableDirections(fromNode: TileNode) -> [Direction] {
         var directions = [Direction]()
         
@@ -121,6 +189,9 @@ class Grid {
 }
 
 extension Grid: SequenceType {
+    /// Generator for Grid to allow it to be iterable
+    ///
+    /// :returns: A generator of TileNodes.
     func generate() -> GeneratorOf<TileNode> {
         var nextRow = 0
         var nextColumn = 0
@@ -132,24 +203,25 @@ extension Grid: SequenceType {
                 nextColumn = 0
                 nextRow++
             }
-            return self.grid[GridIndex(nextRow, nextColumn++)]
+            return self.tileNodes[GridIndex(nextRow, nextColumn++)]
         }
     }
 }
 
+/// A structure to encapsulate the row and column information of a TileNode.
 struct GridIndex {
     private var x: Int
     private var y: Int
-    
+
     init(_ row: Int, _ col: Int) {
         self.x = row
         self.y = col
     }
-    
+
     var row: Int {
         return self.x
     }
-    
+
     var col: Int {
         return self.y
     }

--- a/Cattac/Cattac/GridIndex.swift
+++ b/Cattac/Cattac/GridIndex.swift
@@ -1,0 +1,30 @@
+/// A structure to encapsulate the row and column information of a TileNode.
+struct GridIndex {
+    private var x: Int
+    private var y: Int
+
+    init(_ row: Int, _ col: Int) {
+        self.x = row
+        self.y = col
+    }
+
+    var row: Int {
+        return self.x
+    }
+
+    var col: Int {
+        return self.y
+    }
+}
+
+extension GridIndex: Hashable {
+    var hashValue: Int {
+        get {
+            return (UInt32(y) + UInt32(x) << 16).hashValue
+        }
+    }
+}
+
+func ==(lhs: GridIndex, rhs: GridIndex) -> Bool {
+    return lhs.hashValue == rhs.hashValue
+}

--- a/Cattac/Cattac/LevelGenerator.swift
+++ b/Cattac/Cattac/LevelGenerator.swift
@@ -31,7 +31,7 @@ class LevelGenerator {
             }
         }
         
-        level.constructGraph()
+        level.grid.constructGraph()
         
         generateDoodadAndWalls(level)
         
@@ -80,7 +80,7 @@ class LevelGenerator {
                 }
                 
                 let tileNode = level.addDoodad(doodad, atLocation:location)
-                level.graph.removeNode((Node(tileNode)))
+                level.grid.removeNodeFromGraph(tileNode)
                 
                 hasWallBeenAdded = true
             }
@@ -97,7 +97,7 @@ class LevelGenerator {
             }
         }
         
-        level.constructGraph()
+        level.grid.constructGraph()
         
         for key in aDictionaryFromFirebase.keys {
             let row: Int = key / 10

--- a/Cattac/Cattac/Node.swift
+++ b/Cattac/Cattac/Node.swift
@@ -1,16 +1,13 @@
-/*
-    `Node` represents a vertex in a graph. `Node` is a generic type
-    with a type parameter `T` that is the type of the node's label.
-    For example, `Node<String>` is the type of nodes with a String label
-    and `Node<Int>` is the type of nodes with a Int Label.
-
-    Because we need to compare the node label and store them in a dictionary, the type parameter `T`
-    needs to conform to `Hashable` protocol.
-*/
-
+/// `Node` represents a vertex in a graph. `Node` is a generic type
+/// with a type parameter `T` that is the type of the node's label.
+/// For example, `Node<String>` is the type of nodes with a String label
+/// and `Node<Int>` is the type of nodes with a Int Label.
+///
+/// Because we need to compare the node label and store them in a dictionary, 
+/// the type parameter `T` needs to conform to `Hashable` protocol.
 struct Node<T: Hashable> {
     private var label: T
-    
+
     init(_ label: T) {
         self.label = label
     }
@@ -21,7 +18,7 @@ extension Node: Hashable {
     var hashValue: Int {
         return self.label.hashValue
     }
-    
+
     func getLabel() -> T {
         return self.label
     }


### PR DESCRIPTION
Currently for our levels we have two data structures for the `TileNodes`, a graph and a grid. It makes no sense for these two to exists at the same time in classes such as `GameEngine`. 

The graph is basically a data structure that the grid uses to perform graph calculations such as shortest path, thus it has been moved into `Grid` as a private property. The other classes that uses existing `Graph` methods will call the new wrapper methods provided by `Grid`, and there will be no more need to perform `Node` wrapping and unwrapping since the methods in `Grid` will be the ones doing it.

Proper swift documentation has also been added for `Grid` and `Graph` so that you can now view them using option-click on the methods and properties.

This resolves #28.
