### PR TITLE
Improvement/action buttons

### DIFF
--- a/Cattac/Cattac.xcodeproj/project.pbxproj
+++ b/Cattac/Cattac.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		7661CF481AD4333E0004B0FD /* GridIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7661CF471AD4333E0004B0FD /* GridIndex.swift */; };
 		7661CF4A1AD4336C0004B0FD /* Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7661CF491AD4336C0004B0FD /* Direction.swift */; };
 		7661CF4C1AD560400004B0FD /* GameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7661CF4B1AD560400004B0FD /* GameManager.swift */; };
+		7676FEB91AE29400008FDC9D /* SKPuiActionButtonNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7676FEB81AE29400008FDC9D /* SKPuiActionButtonNode.swift */; };
 		768383E21ADBD44900538F5D /* Grid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FC46E91ABFEB4E0056B5F5 /* Grid.swift */; };
 		768383E31ADBD44900538F5D /* GridIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7661CF471AD4333E0004B0FD /* GridIndex.swift */; };
 		768383E41ADBD44900538F5D /* Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7661CF491AD4336C0004B0FD /* Direction.swift */; };
@@ -216,6 +217,7 @@
 		7661CF471AD4333E0004B0FD /* GridIndex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridIndex.swift; sourceTree = "<group>"; };
 		7661CF491AD4336C0004B0FD /* Direction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Direction.swift; sourceTree = "<group>"; };
 		7661CF4B1AD560400004B0FD /* GameManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameManager.swift; sourceTree = "<group>"; };
+		7676FEB81AE29400008FDC9D /* SKPuiActionButtonNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKPuiActionButtonNode.swift; sourceTree = "<group>"; };
 		768384041ADBD55B00538F5D /* GridTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GridTests.swift; sourceTree = "<group>"; };
 		7689FC971ADAD41E0086613D /* GameAI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameAI.swift; sourceTree = "<group>"; };
 		76D0F60A1ADAF65700CB91B3 /* GameState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameState.swift; sourceTree = "<group>"; };
@@ -366,6 +368,7 @@
 				342584E41AACDB03004A3CFD /* GameScene.sks */,
 				342584E61AACDB03004A3CFD /* GameScene.swift */,
 				763E71281AD2F26500E90EF0 /* SKActionButtonNode.swift */,
+				7676FEB81AE29400008FDC9D /* SKPuiActionButtonNode.swift */,
 				763E71321AD2FFB200E90EF0 /* SKDirectionButtonNode.swift */,
 			);
 			name = Scenes;
@@ -785,6 +788,7 @@
 				342584E91AACDB03004A3CFD /* GameViewController.swift in Sources */,
 				34BA89CB1ADA7CC500413C1B /* StringUtils.swift in Sources */,
 				342584E31AACDB03004A3CFD /* AppDelegate.swift in Sources */,
+				7676FEB91AE29400008FDC9D /* SKPuiActionButtonNode.swift in Sources */,
 				34BA89C81AD6D55200413C1B /* ConnectionManager.swift in Sources */,
 				34B4B20B1AD29B8F00D06BD8 /* LobbyViewController.swift in Sources */,
 				342585531AACE392004A3CFD /* MenuViewController.swift in Sources */,

--- a/Cattac/Cattac/Action.swift
+++ b/Cattac/Cattac/Action.swift
@@ -76,12 +76,9 @@ func ==(lhs: Action, rhs: Action) -> Bool {
 }
 
 class PuiAction: Action {
-    var availableDirections: [Direction]!
-    
     init(direction: Direction) {
         super.init(actionType: ActionType.Pui)
         self._direction = direction
-        self.availableDirections = []
     }
 }
 

--- a/Cattac/Cattac/GameEngine.swift
+++ b/Cattac/Cattac/GameEngine.swift
@@ -97,6 +97,10 @@ class GameEngine {
             self.notifyAction()
         }
 
+        self.on("clearAction") {
+            self.gameManager[actionOf: self.currentPlayer] = nil
+        }
+
         self.on("playerActionEnded") {
             self.triggerStateAdvance()
         }

--- a/Cattac/Cattac/GameScene.swift
+++ b/Cattac/Cattac/GameScene.swift
@@ -30,6 +30,9 @@ class GameScene: SKScene, GameStateListener, ActionListener {
     /// The button layer that consists of the main buttons for the actions.
     private let buttonLayer = SKNode()
 
+    /// All action buttons.
+    private var actionButtons = [SKActionButtonNode]()
+
     /// Button that sets the action of the player to Pui.
     private var puiButton: SKActionButtonNode!
 
@@ -141,23 +144,35 @@ class GameScene: SKScene, GameStateListener, ActionListener {
         puiButton = SKActionButtonNode(
             defaultButtonImage: "PuiButton.png",
             activeButtonImage: "PuiButtonPressed.png",
-            buttonAction: { self.gameEngine.trigger("puiButtonPressed") })
+            buttonAction: { self.gameEngine.trigger("puiButtonPressed") },
+            unselectAction: {
+                self.clearDirectionArrows()
+                self.gameEngine.trigger("clearAction")
+            })
         puiButton.position = CGPoint(x: 0 * buttonSpacing, y: 0)
         buttonLayer.addChild(puiButton)
+        actionButtons.append(puiButton)
 
         fartButton = SKActionButtonNode(
             defaultButtonImage: "FartButton.png",
             activeButtonImage: "FartButtonPressed.png",
-            buttonAction: { self.gameEngine.trigger("fartButtonPressed") })
+            buttonAction: { self.gameEngine.trigger("fartButtonPressed") },
+            unselectAction: { self.gameEngine.trigger("clearAction") })
         fartButton.position = CGPoint(x: 1 * buttonSpacing, y: 0)
         buttonLayer.addChild(fartButton)
+        actionButtons.append(fartButton)
 
         poopButton = SKActionButtonNode(
             defaultButtonImage: "PoopButton.png",
             activeButtonImage: "PoopButtonPressed.png",
-            buttonAction: { self.gameEngine.trigger("poopButtonPressed") })
+            buttonAction: { self.gameEngine.trigger("poopButtonPressed") },
+            unselectAction: {
+                self.hidePoop()
+                self.gameEngine.trigger("clearAction")
+            })
         poopButton.position = CGPoint(x: 2 * buttonSpacing, y: 0)
         buttonLayer.addChild(poopButton)
+        actionButtons.append(poopButton)
     }
 
     /// Initializes the preview node for the current player.
@@ -457,6 +472,7 @@ class GameScene: SKScene, GameStateListener, ActionListener {
             // intuitively hide poop preview only after pooper moved away
             hidePoop()
             performActions()
+            unselectActionButtons()
         default:
             break
         }
@@ -472,10 +488,27 @@ class GameScene: SKScene, GameStateListener, ActionListener {
             case .Pui:
                 drawDirectionArrows(action as PuiAction)
                 hidePoop()
+                unselectActionButtonsExcept(puiButton)
             case .Fart:
                 hidePoop()
+                unselectActionButtonsExcept(fartButton)
             case .Poop:
                 drawPoop(action as PoopAction)
+                unselectActionButtonsExcept(poopButton)
+            }
+        }
+    }
+
+    func unselectActionButtons() {
+        for button in actionButtons {
+            button.unselect()
+        }
+    }
+
+    func unselectActionButtonsExcept(actionButton: SKActionButtonNode) {
+        for button in actionButtons {
+            if button != actionButton {
+                button.unselect()
             }
         }
     }

--- a/Cattac/Cattac/GameViewController.swift
+++ b/Cattac/Cattac/GameViewController.swift
@@ -90,7 +90,7 @@ class GameViewController: UIViewController {
         
         if currentTime == 0 {
             if isPlayerTurn {
-                scene.gameEngine.trigger("playerActionEnded")
+                scene.gameEngine.triggerPlayerActionEnded()
                 isPlayerTurn = false
             } else if scene.gameEngine.state == .PlayerAction {
                 timerLabel.text = "10"

--- a/Cattac/Cattac/SKActionButtonNode.swift
+++ b/Cattac/Cattac/SKActionButtonNode.swift
@@ -10,15 +10,20 @@ import Foundation
 import SpriteKit
 
 class SKActionButtonNode: SKNode {
-    var defaultButton: SKSpriteNode!
-    var activeButton: SKSpriteNode!
-    var action: () -> Void
+    private var defaultButton: SKSpriteNode!
+    private var activeButton: SKSpriteNode!
+    private var action: () -> Void
+    private var unselectAction: () -> Void
+    private var isSelected: Bool
     
-    init(defaultButtonImage: String, activeButtonImage: String, buttonAction: () -> Void) {
+    init(defaultButtonImage: String, activeButtonImage: String,
+        buttonAction: () -> Void, unselectAction: () -> Void) {
         self.defaultButton = SKSpriteNode(imageNamed: defaultButtonImage)
         self.activeButton = SKSpriteNode(imageNamed: activeButtonImage)
         self.action = buttonAction
+        self.unselectAction = unselectAction
         self.activeButton.hidden = true
+        self.isSelected = false
         
         super.init()
         
@@ -27,13 +32,19 @@ class SKActionButtonNode: SKNode {
         addChild(activeButton)
     }
 
+    func unselect() {
+        activeButton.hidden = true
+        defaultButton.hidden = false
+        isSelected = false
+    }
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
     override func touchesBegan(touches: NSSet, withEvent event: UIEvent) {
-        activeButton.hidden = false
-        defaultButton.hidden = true
+        activeButton.hidden = false ^ isSelected
+        defaultButton.hidden = true ^ isSelected
     }
     
     override func touchesMoved(touches: NSSet, withEvent event: UIEvent) {
@@ -41,11 +52,11 @@ class SKActionButtonNode: SKNode {
         var location = touch.locationInNode(self)
         
         if defaultButton.containsPoint(location) {
-            activeButton.hidden = false
-            defaultButton.hidden = true
+            activeButton.hidden = false ^ isSelected
+            defaultButton.hidden = true ^ isSelected
         } else {
-            activeButton.hidden = true
-            defaultButton.hidden = false
+            activeButton.hidden = true ^ isSelected
+            defaultButton.hidden = false ^ isSelected
         }
     }
     
@@ -54,10 +65,16 @@ class SKActionButtonNode: SKNode {
         let location = touch.locationInNode(self)
         
         if defaultButton.containsPoint(location) {
-            action()
+            if !isSelected {
+                action()
+                isSelected = true
+            } else {
+                unselectAction()
+                unselect()
+            }
+        } else {
+            activeButton.hidden = true ^ isSelected
+            defaultButton.hidden = false ^ isSelected
         }
-        
-        activeButton.hidden = true
-        defaultButton.hidden = false
     }
 }

--- a/Cattac/Cattac/SKActionButtonNode.swift
+++ b/Cattac/Cattac/SKActionButtonNode.swift
@@ -9,27 +9,32 @@
 import Foundation
 import SpriteKit
 
-class SKActionButtonNode: SKNode {
+protocol ActionButton {
+    func unselect()
+}
+
+class SKActionButtonNode: SKNode, ActionButton {
     private var defaultButton: SKSpriteNode!
     private var activeButton: SKSpriteNode!
     private var action: () -> Void
     private var unselectAction: () -> Void
-    private var isSelected: Bool
+    var isEnabled = false
+    var isSelected: Bool
     
     init(defaultButtonImage: String, activeButtonImage: String,
         buttonAction: () -> Void, unselectAction: () -> Void) {
-        self.defaultButton = SKSpriteNode(imageNamed: defaultButtonImage)
-        self.activeButton = SKSpriteNode(imageNamed: activeButtonImage)
-        self.action = buttonAction
-        self.unselectAction = unselectAction
-        self.activeButton.hidden = true
-        self.isSelected = false
-        
-        super.init()
-        
-        userInteractionEnabled = true
-        addChild(defaultButton)
-        addChild(activeButton)
+            self.defaultButton = SKSpriteNode(imageNamed: defaultButtonImage)
+            self.activeButton = SKSpriteNode(imageNamed: activeButtonImage)
+            self.action = buttonAction
+            self.unselectAction = unselectAction
+            self.activeButton.hidden = true
+            self.isSelected = false
+            
+            super.init()
+            
+            userInteractionEnabled = true
+            addChild(defaultButton)
+            addChild(activeButton)
     }
 
     func unselect() {
@@ -43,14 +48,22 @@ class SKActionButtonNode: SKNode {
     }
     
     override func touchesBegan(touches: NSSet, withEvent event: UIEvent) {
+        if !isEnabled {
+            return
+        }
+
         activeButton.hidden = false ^ isSelected
         defaultButton.hidden = true ^ isSelected
     }
     
     override func touchesMoved(touches: NSSet, withEvent event: UIEvent) {
+        if !isEnabled {
+            return
+        }
+
         var touch = touches.allObjects[0] as UITouch
         var location = touch.locationInNode(self)
-        
+
         if defaultButton.containsPoint(location) {
             activeButton.hidden = false ^ isSelected
             defaultButton.hidden = true ^ isSelected
@@ -61,9 +74,13 @@ class SKActionButtonNode: SKNode {
     }
     
     override func touchesEnded(touches: NSSet, withEvent event: UIEvent) {
+        if !isEnabled {
+            return
+        }
+
         let touch = touches.allObjects[0] as UITouch
         let location = touch.locationInNode(self)
-        
+
         if defaultButton.containsPoint(location) {
             if !isSelected {
                 action()

--- a/Cattac/Cattac/SKDirectionButtonNode.swift
+++ b/Cattac/Cattac/SKDirectionButtonNode.swift
@@ -1,28 +1,18 @@
-//
-//  SKDirectionButtonNode.swift
-//  Cattac
-//
-//  Created by Wu Di on 7/4/15.
-//  Copyright (c) 2015 National University of Singapore (Department of Computer Science). All rights reserved.
-//
-
 import Foundation
 import SpriteKit
 
+/// Button for Actions.
+///
+/// Touch to select and unselect.
 class SKDirectionButtonNode: SKNode {
     private var defaultTexture: SKTexture!
     private var activeTexture: SKTexture!
-    var top: SKSpriteNode!
-    var right: SKSpriteNode!
-    var bottom: SKSpriteNode!
-    var left: SKSpriteNode!
     private var buttons: [Direction:SKSpriteNode] = [:]
-    private var selectedButton: SKSpriteNode!
-    var action: (Direction) -> Void
+    private var selectedButton: SKSpriteNode?
+    var selectedDirection: Direction?
     
-    init(defaultButtonImage: String, activeButtonImage: String, size: CGSize, centerSize: CGSize, hoverAction: (Direction) -> Void, availableDirection: [Direction], selected: Direction) {
-        
-        self.action = hoverAction
+    init(defaultButtonImage: String, activeButtonImage: String, size: CGSize,
+        centerSize: CGSize, availableDirection: [Direction]) {
         
         super.init()
         
@@ -30,37 +20,27 @@ class SKDirectionButtonNode: SKNode {
         self.activeTexture = SKTexture(imageNamed: activeButtonImage)
         
         for direction in availableDirection {
-            var button: SKSpriteNode
-            if direction == selected {
-                button = SKSpriteNode(texture: self.activeTexture)
-                selectedButton = button
-            } else {
-                button = SKSpriteNode(texture: self.defaultTexture)
-            }
+            var button = SKSpriteNode(texture: self.defaultTexture)
             button.size = size
             button.zRotation = SceneUtils.zRotation(direction)
             
             switch direction {
             case .Top:
-                top = button
                 button.position = CGPoint(
                     x: 0,
                     y: CGFloat((centerSize.height + size.height) / 2.0)
                 )
             case .Right:
-                right = button
                 button.position = CGPoint(
                     x: CGFloat((centerSize.width + size.width) / 2.0),
                     y: 0
                 )
             case .Bottom:
-                bottom = button
                 button.position = CGPoint(
                     x: 0,
                     y: -CGFloat((centerSize.height + size.height) / 2.0)
                 )
             case .Left:
-                left = button
                 button.position = CGPoint(
                     x: -CGFloat((centerSize.width + size.width) / 2.0),
                     y: 0
@@ -79,31 +59,25 @@ class SKDirectionButtonNode: SKNode {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    override func touchesBegan(touches: NSSet, withEvent event: UIEvent) {
-        var touch = touches.allObjects[0] as UITouch
-        processTouchEvent(touch.locationInNode(self))
+
+    func selectDirection(dir: Direction) {
+        if selectedButton != nil {
+            selectedButton!.texture = defaultTexture
+        }
+
+        if let button = buttons[dir] {
+            button.texture = activeTexture
+            selectedButton = button
+            selectedDirection = dir
+        }
     }
-    
-    override func touchesMoved(touches: NSSet, withEvent event: UIEvent) {
-        var touch = touches.allObjects[0] as UITouch
-        processTouchEvent(touch.locationInNode(self))
-    }
-    
-    override func touchesEnded(touches: NSSet, withEvent event: UIEvent) {
-        var touch = touches.allObjects[0] as UITouch
-        processTouchEvent(touch.locationInNode(self))
-    }
-    
-    private func processTouchEvent(location: CGPoint) {
-        for (direction, button) in buttons {
-            if button.containsPoint(location) {
-                action(direction)
-                selectedButton.texture = defaultTexture
-                button.texture = activeTexture
-                selectedButton = button
-                break
-            }
+
+    func unselectDirection() {
+        selectedDirection = nil
+
+        if selectedButton != nil {
+            selectedButton!.texture = defaultTexture
+            selectedButton = nil
         }
     }
 }

--- a/Cattac/Cattac/SKPuiActionButtonNode.swift
+++ b/Cattac/Cattac/SKPuiActionButtonNode.swift
@@ -1,0 +1,154 @@
+import Foundation
+import SpriteKit
+
+/// Button for Pui Action, extension of Action Button.
+///
+/// Adds functionality to register swiping from the button to register the pui
+/// direction.
+class SKPuiActionButtonNode: SKActionButtonNode {
+    /// Called to set the puiAction in the provided direction
+    private var buttonAction: (Direction) -> Void
+
+    /// Called to clear the puiAction
+    private var unselectAction: () -> ()
+
+    /// Called to retrieve all the available directions for the cat
+    private var getAvailableDirections: () -> [Direction]
+
+    /// The direction arrows
+    private var directionNode: SKDirectionButtonNode?
+
+    /// The point where the user begins touching the button
+    private var initialTouchLocation: CGPoint?
+
+    /// The minimum distance before registering a direction
+    private let minimumTriggerDistance: CGFloat = 20
+
+    /// Hijacks the buttonAction and unselectAction from the superclass as
+    /// we will be calling them under different conditions.
+    init(defaultButtonImage: String, activeButtonImage: String,
+        buttonAction: (Direction) -> Void, unselectAction: () -> Void,
+        getAvailableDirections: () -> [Direction]) {
+            self.getAvailableDirections = getAvailableDirections
+            self.buttonAction = buttonAction
+            self.unselectAction = unselectAction
+
+            super.init(
+                defaultButtonImage: defaultButtonImage,
+                activeButtonImage: activeButtonImage,
+                buttonAction: {},
+                unselectAction: {}
+            )
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Removes the directional arrows in addition to unselecting the button
+    override func unselect() {
+        super.unselect()
+        if directionNode != nil {
+            directionNode!.removeFromParent()
+            directionNode = nil
+        }
+    }
+
+    override func touchesBegan(touches: NSSet, withEvent event: UIEvent) {
+        if !isEnabled {
+            return
+        }
+
+        super.touchesBegan(touches, withEvent: event)
+
+        /// Register the inital touch point to calculate swipe direction later
+        var touch = touches.allObjects[0] as UITouch
+        initialTouchLocation = touch.locationInNode(self)
+
+        /// Resets the direction on touch begin or create the direction arrows
+        /// if they do not exist
+        if directionNode == nil {
+            directionNode = SKDirectionButtonNode(
+                defaultButtonImage: "Direction.png",
+                activeButtonImage: "DirectionSelected",
+                size: CGSize(width: 50, height: 50),
+                centerSize: self.calculateAccumulatedFrame().size,
+                availableDirection: getAvailableDirections())
+            self.addChild(directionNode!)
+        } else {
+            directionNode!.unselectDirection()
+            unselectAction()
+        }
+    }
+
+    override func touchesMoved(touches: NSSet, withEvent event: UIEvent) {
+        /// directionNode will be cleared when the gameState changes, so we
+        /// need to disable all touchesMoved operations
+        if !isEnabled || directionNode == nil {
+            return
+        }
+
+        var touch = touches.allObjects[0] as UITouch
+        var location = touch.locationInNode(self)
+
+        /// If the minimumTriggerDistance is met, selects the arrow in that 
+        /// direction and trigger the buttonAction, else trigger the clearing 
+        /// of the puiAction
+        if distanceBetween(fromPoint: initialTouchLocation!,
+            toPoint: location) > minimumTriggerDistance {
+                let degree = CGPointToDegree(fromPoint: initialTouchLocation!,
+                    toPoint: location)
+
+                switch degree {
+                case -180...(-135):
+                    directionNode!.selectDirection(.Right)
+                case -135...(-45):
+                    directionNode!.selectDirection(.Top)
+                case -45..<45:
+                    directionNode!.selectDirection(.Left)
+                case 45..<135:
+                    directionNode!.selectDirection(.Bottom)
+                case 135...180:
+                    directionNode!.selectDirection(.Right)
+                default:
+                    break
+                }
+
+                buttonAction(directionNode!.selectedDirection!)
+        } else {
+            directionNode!.unselectDirection()
+            unselectAction()
+        }
+    }
+
+    override func touchesEnded(touches: NSSet, withEvent event: UIEvent) {
+        /// directionNode will be cleared when the gameState changes, so we
+        /// need to disable touchesEnded operation
+        if !isEnabled || directionNode == nil {
+            return
+        }
+
+        /// Calls buttonAction to trigger the puiAction if a direction is set,
+        /// else unselects the button and clear the direction arrows.
+        if let direction = directionNode!.selectedDirection {
+            buttonAction(direction)
+        } else {
+            unselect()
+            unselectAction()
+        }
+    }
+
+    private func distanceBetween(# fromPoint: CGPoint, toPoint: CGPoint)
+        -> CGFloat {
+            return hypot(fromPoint.x - toPoint.x, fromPoint.y - toPoint.y)
+    }
+
+    private func CGPointToDegree(# fromPoint: CGPoint, toPoint: CGPoint)
+        -> CGFloat {
+            let x = fromPoint.x - toPoint.x
+            let y = fromPoint.y - toPoint.y
+            let bearingRadians = atan2(y, x);
+            let bearingDegrees = bearingRadians * (180 / CGFloat(M_PI));
+            return bearingDegrees;
+    }
+}


### PR DESCRIPTION
Changes include:
- Selected action button remains selected so that the player knows which action they are using
- Able to unselect actions
- Swipe from pui button to determine pui direction
- Buttons enabled only when `gameState` is at `.PlayerAction`
- `PuiAction` no longer needs to hold information about the available directions.
- All action buttons will be unselected at `.PostExecute`
- No longer using events in `gameEngine`, all changed to used functions instead. These functions are moved to an extension of `gameEngine` at the bottom of the file for better organisation.
